### PR TITLE
Bump base bounds

### DIFF
--- a/seqid.cabal
+++ b/seqid.cabal
@@ -19,7 +19,7 @@ source-repository head
 
 library
   exposed-modules: Data.SequenceId
-  build-depends: base         >= 4.7 && < 4.12
+  build-depends: base         >= 4.7 && < 4.14
                , mtl          >= 2.2 && < 2.3
                , transformers >= 0.4 && < 0.6
 


### PR DESCRIPTION
This enables building with GHC 8.6.5 and 8.8.1